### PR TITLE
Fixing invalid CSS property

### DIFF
--- a/templates/css.ts
+++ b/templates/css.ts
@@ -10,5 +10,5 @@ body {
 *,
 *:before,
 *:after {
-  box-sizing: 'border-box';
+  box-sizing: border-box;
 }`


### PR DESCRIPTION
`box-sizing: 'border-box';` is invalid CSS.

The valid format for this is `box-sizing: border-box;` (no quote marks)

This also adds the benefit of previewing what a string looks like in CSS without quote marks.